### PR TITLE
Fix some small errors

### DIFF
--- a/example2.js
+++ b/example2.js
@@ -1,0 +1,23 @@
+import { getRecordsByQuery } from './src/index';
+
+
+const initParams = {
+  query: '',
+  alisEndpoint: 'http://86.57.174.45',
+  recordType: 'Книги',
+  queryType: 'Все',
+};
+
+const cb = (err, memo) => {
+  if (err) {
+    if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET') {
+      console.log(err.code, 'restart');
+      getRecordsByQuery(initParams, cb);
+    }
+    console.log(err.message);
+  } else {
+    console.log('memo.length All: ', memo.length);
+  }
+};
+
+getRecordsByQuery(initParams, cb);

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,9 @@ export function getPage(options, callback) {
     if (err) {
       return callback(err);
     }
+    if (response.body.match('Ошибка')) {
+      return callback(new Error('alert Ошибка'));
+    }
     callback(null, body);
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ export function sendInitialQuery(params, callback) {
   if (!params.alisEndpoint) {
     return process.nextTick(callback, new Error('alisEndpoint is not provided'));
   }
-  if (!params.query) {
+  if (!params.query && params.query !== '') {
     return process.nextTick(callback, new Error('query is not provided'));
   }
   if (!params.queryType) {

--- a/src/index.js
+++ b/src/index.js
@@ -133,8 +133,8 @@ export function getRecordsByQuery(initParams, callback) {
     const firstNumberedPageUrls = getNumberedPageUrls($);
     const remainingQueue = firstNumberedPageUrls;
     run(processItems, remainingQueue, [], options, (runErr, memo) => {
-      if (err) {
-        return callback(err);
+      if (runErr) {
+        return callback(runErr);
       }
       callback(null, memo);
     });


### PR DESCRIPTION
added ability to request data with empty query string
fix error's obj name: `return callback(runErr)` instead `return callback(err)`
catch error, when server return empty page with 'alert(Ошибка)',  without any mark of error
